### PR TITLE
Add GitHub Actions workflow to run __main__.py every 60 seconds

### DIFF
--- a/.github/workflows/run_main.yml
+++ b/.github/workflows/run_main.yml
@@ -1,0 +1,27 @@
+name: Run Main Script
+
+on:
+  schedule:
+    - cron: "*/1 * * * *"
+
+jobs:
+  run-main:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests nbtlib
+
+    - name: Run main script
+      run: |
+        python __main__.py


### PR DESCRIPTION
Add a GitHub Actions workflow to run `__main__.py` every 60 seconds.

* **Workflow Configuration**
  - Create `.github/workflows/run_main.yml` file.
  - Schedule the workflow to run every 60 seconds using cron expression `*/1 * * * *`.

* **Job Definition**
  - Define a job named `run-main` to run on `ubuntu-latest`.
  - Checkout the repository using `actions/checkout@v2`.
  - Set up Python environment using `actions/setup-python@v2`.
  - Install dependencies `requests` and `nbtlib`.
  - Run the `__main__.py` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UltimateBoi/AhAveragesPy/pull/2?shareId=3e966064-f769-4ba1-ab44-ad568be28136).